### PR TITLE
Added UIDs to events to improve compatibility with fhem CALENDAR module.

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -11,13 +11,13 @@ import os
 import re
 import subprocess
 import tempfile
-
+import uuid
+from socket import gethostname
 
 from BeautifulSoup import BeautifulSoup
 from icalendar import Calendar, Event
 import logbook
 import requests
-from socket import gethostname
 
 OUTPUT_DIR = '/home/kopf/www/gsack-output'
 
@@ -58,7 +58,7 @@ def generate_ics_file(uid, data):
         event.add('summary', 'Gelber Sack Abholtermin')
         event.add('dtstart', start)
         event.add('dtend', end)
-        event.add('uid', datetime.now().strftime("%Y%m%dT%H%M%S-%f") + "@" + gethostname())
+        event.add('uid', str(uuid.uuid4()) + "@" + gethostname())
         cal.add_component(event)
     filename = '{0}.ics'.format(uid)
     with open(os.path.join(OUTPUT_DIR, filename), 'wb') as f:

--- a/scrape.py
+++ b/scrape.py
@@ -17,6 +17,7 @@ from BeautifulSoup import BeautifulSoup
 from icalendar import Calendar, Event
 import logbook
 import requests
+from socket import gethostname
 
 OUTPUT_DIR = '/home/kopf/www/gsack-output'
 
@@ -57,6 +58,7 @@ def generate_ics_file(uid, data):
         event.add('summary', 'Gelber Sack Abholtermin')
         event.add('dtstart', start)
         event.add('dtend', end)
+        event.add('uid', datetime.now().strftime("%Y%m%dT%H%M%S-%f") + "@" + gethostname())
         cal.add_component(event)
     filename = '{0}.ics'.format(uid)
     with open(os.path.join(OUTPUT_DIR, filename), 'wb') as f:


### PR DESCRIPTION
According to RFC 5545, VEVENT records must have a UID (see Ch. 3.8.4.7 Unique Identifier). Some clients fail if a UID is missing, e.g. the CALENDAR component of the fhem smart-home software.

This pull requests improves conformance to RFC 5545, and allows the output to be used in fhem, e.g. to remind everyone at home that the Gelber Sack is about to be picked up.